### PR TITLE
fix: 3 bugs blocking live DMWork database analysis

### DIFF
--- a/src/layer1/base-adapter.ts
+++ b/src/layer1/base-adapter.ts
@@ -105,7 +105,7 @@ export abstract class BaseAdapter {
           name: user.name,
           role: user.role,
           team: user.team,
-          email: user.email,
+          email: (user.email && user.email.includes('@')) ? user.email : undefined,
           type: 'human',
           created_at: user.created_at,
         });

--- a/src/layer1/dmwork-adapter.ts
+++ b/src/layer1/dmwork-adapter.ts
@@ -45,6 +45,7 @@ interface PayloadData {
 
 export class DMWorkAdapter extends BaseAdapter {
   private pool: mysql.Pool;
+  private groupMemberCache: Map<string, string[]> = new Map();
   
   constructor(config: DMWorkConfig) {
     super(config);
@@ -88,7 +89,7 @@ export class DMWorkAdapter extends BaseAdapter {
       id: user.uid,
       name: user.name,
       is_bot: Boolean(user.robot),
-      email: user.email || undefined,
+      email: (user.email && user.email.includes('@')) ? user.email : undefined,
       creator_uid: Boolean(user.robot) ? robotCreators.get(user.uid) : undefined,
     }));
     
@@ -118,12 +119,12 @@ export class DMWorkAdapter extends BaseAdapter {
       
       if (startTime) {
         query += ' AND created_at >= ?';
-        params.push(Math.floor(startTime.getTime() / 1000));
+        params.push(startTime);
       }
       
       if (endTime) {
         query += ' AND created_at <= ?';
-        params.push(Math.floor(endTime.getTime() / 1000));
+        params.push(endTime);
       }
       
       const [rows] = await this.pool.query<mysql.RowDataPacket[]>(query, params);
@@ -138,7 +139,7 @@ export class DMWorkAdapter extends BaseAdapter {
           from_uid: row.from_uid,
           to_uids: toUids,
           content: this._extractContent(row.payload),
-          timestamp: new Date(row.created_at * 1000),
+          timestamp: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
           context_id: row.channel_id,
         });
       }
@@ -179,14 +180,19 @@ export class DMWorkAdapter extends BaseAdapter {
       }
     }
     
-    // Source 2: If no mentions, infer from group context
+    // Source 2: If no mentions, infer from group context (with cache)
     if (toUids.length === 0 && msg.channel_id) {
-      const [members] = await this.pool.query<mysql.RowDataPacket[]>(
-        'SELECT uid FROM group_member WHERE group_no = ? AND uid != ? LIMIT 50',
-        [msg.channel_id, msg.from_uid]
-      );
+      let memberUids = this.groupMemberCache.get(msg.channel_id);
+      if (!memberUids) {
+        const [members] = await this.pool.query<mysql.RowDataPacket[]>(
+          'SELECT uid FROM group_member WHERE group_no = ? LIMIT 50',
+          [msg.channel_id]
+        );
+        memberUids = members.map(m => m.uid);
+        this.groupMemberCache.set(msg.channel_id, memberUids);
+      }
       
-      toUids.push(...members.map(m => m.uid));
+      toUids.push(...memberUids.filter(uid => uid !== msg.from_uid));
     }
     
     return toUids;

--- a/src/layer2/models.ts
+++ b/src/layer2/models.ts
@@ -25,7 +25,7 @@ export const HumanNodeSchema = z.object({
   team: z.string().optional().describe("Team affiliation (for Silo Index)"),
   
   // Contact (optional)
-  email: z.string().email().optional().describe("Email address"),
+  email: z.string().optional().describe("Email address"),
   timezone: z.string().optional().describe("Timezone"),
   
   // Connoisseurship metrics (Layer 3 annotations) - v1.3.0

--- a/src/layer3/analysis-engine.ts
+++ b/src/layer3/analysis-engine.ts
@@ -72,13 +72,26 @@ export class AnalysisEngine {
       });
     }
     
-    // Add edges
+    // Add edges (skip if source or target node not found)
+    let skippedEdges = 0;
     for (const edge of this.networkGraph.edges) {
-      graph.addEdge(edge.source, edge.target, {
-        weight: edge.weight,
-        edge_type: edge.edge_type,
-        is_cross_team: edge.is_cross_team,
-      });
+      if (graph.hasNode(edge.source) && graph.hasNode(edge.target)) {
+        try {
+          graph.addEdge(edge.source, edge.target, {
+            weight: edge.weight,
+            edge_type: edge.edge_type,
+            is_cross_team: edge.is_cross_team,
+          });
+        } catch (e) {
+          // Skip duplicate edges
+          skippedEdges++;
+        }
+      } else {
+        skippedEdges++;
+      }
+    }
+    if (skippedEdges > 0) {
+      console.log(`Skipped ${skippedEdges} edges (missing nodes or duplicates)`);
     }
     
     this.cache.graph = graph;


### PR DESCRIPTION
## 问题

使用 OCTO-ONA 连接真实 DMWork 数据库分析最近3天数据时，遇到3个阻断性bug。

## 修复内容

### 1. 时间过滤错误 (dmwork-adapter.ts)
- **问题**: `created_at` 是 MySQL DATETIME 类型，但代码用 `Math.floor(getTime()/1000)` 当 unix 秒数比较，导致查询返回0条消息
- **修复**: 直接传 Date 对象给 mysql2，由驱动自动转换

### 2. Email 校验过严 (models.ts + base-adapter.ts + dmwork-adapter.ts)
- **问题**: Zod schema 用 `z.string().email()` 校验，但数据库中有测试邮箱如 `deve@qq.com1`、`vvhnnn@455.33`，导致整个 graph 构建失败
- **修复**: 放宽为 `z.string().optional()`，在 adapter 层过滤空值

### 3. 缺失节点导致 Graph 崩溃 (analysis-engine.ts)
- **问题**: 有些消息的接收者（如"团长"）不在用户表中，`graph.addEdge()` 抛出 `NotFoundGraphError`
- **修复**: 添加 `hasNode()` 前置检查，跳过缺失节点的边

### 4. N+1 查询性能优化 (dmwork-adapter.ts)
- **问题**: 每条消息都查一次 `group_member` 表推断 to_uids，16000条消息 = 16000次 DB 查询
- **修复**: 按 `group_no` 缓存成员列表

## 测试

已在真实 DMWork 数据库上验证（im-test.xming.ai），成功分析 16,361 条消息、747 用户、3天时间窗口，生成完整 Dashboard。